### PR TITLE
machine/*: Don't use IMAGE_INSTALL in machine

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,6 +5,11 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
+BBFILES_DYNAMIC += " \
+    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
+    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
+"
+
 BBFILE_COLLECTIONS += "asus-imx"
 BBFILE_PATTERN_asus-imx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_asus-imx = "9"

--- a/conf/machine/asus-imx8.inc
+++ b/conf/machine/asus-imx8.inc
@@ -83,12 +83,6 @@ SERIAL_CONSOLES = "115200;ttymxc0"
 
 VOLATILE_LOG_DIR = "no"
 
-IMAGE_INSTALL_append += " \
-	asus-overlay \
-	gptfdisk \
-	vim \
-"
-
 SOC_DEFAULT_WKS_FILE_asus = "asus-imx-boot-bootpart.wks.in"
 
 IMAGE_FSTYPES = "wic.bz2"

--- a/conf/machine/imx8mp-blizzard.inc
+++ b/conf/machine/imx8mp-blizzard.inc
@@ -63,16 +63,6 @@ VOLATILE_LOG_DIR = "no"
 
 # Add additional firmware
 MACHINE_FIRMWARE_append = " linux-firmware-ath10k"
-IMAGE_INSTALL_append += " \
-	can-utils \
-	networkmanager \
-	networkmanager-nmcli \
-	networkmanager-nmtui \
-	asus-overlay \
-	gptfdisk \
-	vim \
-	glibc-gconv-utf-16 \
-"
 
 MACHINE_EXTRA_RRECOMMENDS_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'qca6174', 'kernel-module-qca6174 firmware-qca6174 firmware-qca6174-usb qca-tools', '', d)}"
 MACHINE_EXTRA_RRECOMMENDS_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'rtl8822', 'rtk-bt-fw', '', d)}"

--- a/dynamic-layers/qt5-layer/recipes-fsl/images/imx-image-full.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-fsl/images/imx-image-full.bbappend
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Asus
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+SUMMARY = "imx-image-full with a couple additions by Asus"
+LICENSE = "MIT"
+
+IMAGE_INSTALL += " \
+	asus-overlay \
+	can-utils \
+	glibc-gconv-utf-16 \
+	gptfdisk \
+	networkmanager \
+	networkmanager-nmcli \
+	networkmanager-nmtui \
+	vim \
+"


### PR DESCRIPTION
Forcing the installation of packages inside a machine file means that
anybody who doesn't want those packages, must create their own machine
from scratch or use _remove. But if the list of packages is fairly long,
using _remove gets cumbersome and error prone. What this layer should do
instead is just create a new image that installs them in that image.

However, the base image we want to require is imx-image-full, which is
from meta-imx/meta-sdk/dynamic-layers/qt5-layer/, so we should also add
this image in a dynamic-layer, so the users who include this layer
(meta-asus-imx) don't also need to have meta-qt5 since that isn't
otherwise necessary.